### PR TITLE
update WekinatorSquirrelRotator to be OF 0.9.1 ready

### DIFF
--- a/outputs/openFrameworks/Wekinator_Squirrel_Rotator/addons.make
+++ b/outputs/openFrameworks/Wekinator_Squirrel_Rotator/addons.make
@@ -1,0 +1,2 @@
+ofxAssimpModelLoader
+ofxOsc

--- a/outputs/openFrameworks/Wekinator_Squirrel_Rotator/src/ofApp.cpp
+++ b/outputs/openFrameworks/Wekinator_Squirrel_Rotator/src/ofApp.cpp
@@ -121,7 +121,7 @@ void ofApp::draw(){
     glTranslatef(-ofGetWidth()/2,-ofGetHeight()/2,0);
     
     ofSetColor(255, 255, 255, 255);
-    squirrelModel.draw();
+    squirrelModel.draw(OF_MESH_FILL);
     
     glPopMatrix();
     

--- a/outputs/openFrameworks/Wekinator_Squirrel_Rotator/src/ofApp.h
+++ b/outputs/openFrameworks/Wekinator_Squirrel_Rotator/src/ofApp.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "ofMain.h"
-#include "ofx3DModelLoader.h"
+#include "ofxAssimpModelLoader.h"
 #include "ofxOsc.h"
 
 // listen on port 12000
@@ -26,7 +26,7 @@ public:
     void dragEvent(ofDragInfo dragInfo);
     void gotMessage(ofMessage msg);
     
-    ofx3DModelLoader squirrelModel;
+    ofxAssimpModelLoader squirrelModel;
     
     ofxOscReceiver receiver;
     float vx, vy;


### PR DESCRIPTION
Included addon, ofx3DModelLoader was renamed to [ofxAssimpModelLoader](https://github.com/openframeworks/openFrameworks/tree/master/addons/ofxAssimpModelLoader) a while ago. The change was made to use the new one. So it could run with freshly download OF right away. 

addons.make also added to simplify project generation process with PG. 