### PR TITLE
I complained about the Pd input example in the forums, so I fixed it.

### DIFF
--- a/inputs/PD/SimpleSlider_3inputs.pd
+++ b/inputs/PD/SimpleSlider_3inputs.pd
@@ -1,22 +1,22 @@
-#N canvas 498 163 745 419 10;
+#N canvas 492 166 745 419 10;
 #X declare -lib oscx;
-#X msg -210 94 connect localhost 6448;
-#X obj -210 74 loadbang;
+#X msg -210 107 connect localhost 6448;
+#X obj -210 87 loadbang;
 #X obj 10 66 vsl 15 128 0 127 0 0 \$0-lslider empty empty 0 -9 0 10
--262144 -1 -1 3450 1;
+-262144 -1 -1 3800 0;
 #X obj 34 66 vsl 15 128 0 127 0 0 \$0-mslider empty empty 0 -9 0 10
--262144 -1 -1 10750 1;
+-262144 -1 -1 3800 1;
 #X obj 59 66 vsl 15 128 0 127 0 0 \$0-rslider empty empty 0 -9 0 10
--262144 -1 -1 0 1;
+-262144 -1 -1 6700 1;
 #X text -229 -8 This patch sends 3 inputs to wekinator on port 6448
 \, using message /wek/inputs;
-#X text -85 36 Use these sliders to change input values.;
-#X obj -221 250 sendOSC;
-#X obj -223 23 import oscx;
-#X msg -222 53 disconnect;
-#X obj -184 134 r \$0-lslider;
-#X obj -156 155 r \$0-mslider;
-#X obj -127 175 r \$0-rslider;
+#X text -85 39 Use these sliders to change input values.;
+#X obj -221 343 sendOSC;
+#X obj -223 46 import oscx;
+#X msg -222 66 disconnect;
+#X obj -174 182 r \$0-lslider;
+#X obj -156 220 r \$0-mslider;
+#X obj -127 258 r \$0-rslider;
 #X obj 154 303 noise~;
 #X obj 154 322 unsig~;
 #X obj 154 342 expr (1 + $f1) * 63.5 * $f2;
@@ -33,22 +33,28 @@
 #X obj 256 206 r \$0-random-toggle;
 #X obj 97 362 pack f f f;
 #X obj 97 383 s \$0-random-values;
-#X obj -170 250 print;
-#X msg -198 223 send /wek/inputs \$1 \$2 \$3;
-#X obj -184 198 pack f f f;
-#X obj -176 178 t b;
-#X obj -197 115 r \$0-random-values;
+#X obj -170 343 print;
+#X msg -198 316 send /wek/inputs \$1 \$2 \$3;
+#X obj -184 297 pack f f f;
+#X obj -198 127 r \$0-random-values;
 #X text 85 70 Click this checkbox tosend random input values;
 #X text 88 127 ... or both if you feel sassy. :-)Either way \, watch
 the Pd console.;
+#X msg -63 102 \; pd dsp 1;
+#X obj -127 278 + 0.0001;
+#X obj -156 239 + 0.0001;
+#X obj -174 201 + 0.0001;
+#X obj -188 146 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1
+0 1;
+#X obj -188 163 metro 12;
 #X connect 0 0 7 0;
 #X connect 1 0 0 0;
+#X connect 1 0 34 0;
+#X connect 1 0 38 0;
 #X connect 9 0 7 0;
-#X connect 10 0 30 0;
-#X connect 11 0 30 1;
-#X connect 11 0 31 0;
-#X connect 12 0 30 2;
-#X connect 12 0 31 0;
+#X connect 10 0 37 0;
+#X connect 11 0 36 0;
+#X connect 12 0 35 0;
 #X connect 13 0 14 0;
 #X connect 14 0 15 0;
 #X connect 15 0 26 2;
@@ -65,5 +71,9 @@ the Pd console.;
 #X connect 29 0 7 0;
 #X connect 29 0 28 0;
 #X connect 30 0 29 0;
-#X connect 31 0 30 0;
-#X connect 32 0 29 0;
+#X connect 31 0 29 0;
+#X connect 35 0 30 2;
+#X connect 36 0 30 1;
+#X connect 37 0 30 0;
+#X connect 38 0 39 0;
+#X connect 39 0 30 0;

--- a/inputs/PD/SimpleSlider_3inputs.pd
+++ b/inputs/PD/SimpleSlider_3inputs.pd
@@ -1,79 +1,87 @@
 #N canvas 492 166 745 419 10;
 #X declare -lib oscx;
-#X msg -210 107 connect localhost 6448;
-#X obj -210 87 loadbang;
-#X obj 10 66 vsl 15 128 0 127 0 0 \$0-lslider empty empty 0 -9 0 10
--262144 -1 -1 3800 0;
-#X obj 34 66 vsl 15 128 0 127 0 0 \$0-mslider empty empty 0 -9 0 10
--262144 -1 -1 3800 1;
-#X obj 59 66 vsl 15 128 0 127 0 0 \$0-rslider empty empty 0 -9 0 10
--262144 -1 -1 6700 1;
-#X text -229 -8 This patch sends 3 inputs to wekinator on port 6448
+#X text -256 -12 This patch sends 3 inputs to wekinator on port 6448
 \, using message /wek/inputs;
-#X text -85 39 Use these sliders to change input values.;
-#X obj -221 343 sendOSC;
-#X obj -223 46 import oscx;
-#X msg -222 66 disconnect;
-#X obj -174 182 r \$0-lslider;
-#X obj -156 220 r \$0-mslider;
-#X obj -127 258 r \$0-rslider;
-#X obj 154 303 noise~;
-#X obj 154 322 unsig~;
-#X obj 154 342 expr (1 + $f1) * 63.5 * $f2;
-#X obj 88 105 tgl 15 0 \$0-random-toggle empty empty 17 7 0 10 -262144
+#X text -253 83 Use these sliders to change input values.;
+#X obj 124 29 tgl 15 0 \$0-random-toggle empty empty 17 7 0 10 -262144
 -1 -1 0 1;
-#X obj 313 322 r \$0-random-toggle;
-#X obj 125 244 noise~;
-#X obj 125 263 unsig~;
-#X obj 125 283 expr (1 + $f1) * 63.5 * $f2;
-#X obj 284 264 r \$0-random-toggle;
-#X obj 97 166 noise~;
-#X obj 97 185 unsig~;
-#X obj 97 225 expr (1 + $f1) * 63.5 * $f2;
-#X obj 256 206 r \$0-random-toggle;
-#X obj 97 362 pack f f f;
-#X obj 97 383 s \$0-random-values;
-#X obj -170 343 print;
-#X msg -198 316 send /wek/inputs \$1 \$2 \$3;
-#X obj -184 297 pack f f f;
-#X obj -198 127 r \$0-random-values;
-#X text 85 70 Click this checkbox tosend random input values;
-#X text 88 127 ... or both if you feel sassy. :-)Either way \, watch
-the Pd console.;
-#X msg -63 102 \; pd dsp 1;
-#X obj -127 278 + 0.0001;
-#X obj -156 239 + 0.0001;
-#X obj -174 201 + 0.0001;
-#X obj -188 146 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1
-0 1;
-#X obj -188 163 metro 12;
-#X connect 0 0 7 0;
+#X obj -251 65 tgl 15 0 \$0-sliders-on-off \$0-loadbang empty 17 7
+0 10 -262144 -1 -1 0 1;
+#X text -256 33 click here to turn the sliders on/off;
+#X text 153 123 Either way \, watch the Pd console.;
+#N canvas 331 364 450 300 \$0-sliderguts 0;
+#X msg -210 114 connect localhost 6448;
+#X obj -210 94 loadbang;
+#X obj -221 350 sendOSC;
+#X obj -223 53 import oscx;
+#X msg -222 73 disconnect;
+#X obj -174 189 r \$0-lslider;
+#X obj -156 227 r \$0-mslider;
+#X obj -127 265 r \$0-rslider;
+#X obj -170 350 print;
+#X msg -198 323 send /wek/inputs \$1 \$2 \$3;
+#X obj -184 304 pack f f f;
+#X obj -198 134 r \$0-random-values;
+#X msg -63 109 \; pd dsp 1;
+#X obj -127 285 + 0.0001;
+#X obj -156 246 + 0.0001;
+#X obj -174 208 + 0.0001;
+#X obj -188 153 tgl 15 0 empty \$0-sliders-on-off empty 17 7 0 10 -262144
+-1 -1 0 1;
+#X obj -188 170 metro 12;
+#X obj -147 94 s \$0-loadbang;
+#X connect 0 0 2 0;
 #X connect 1 0 0 0;
-#X connect 1 0 34 0;
-#X connect 1 0 38 0;
-#X connect 9 0 7 0;
-#X connect 10 0 37 0;
-#X connect 11 0 36 0;
-#X connect 12 0 35 0;
-#X connect 13 0 14 0;
-#X connect 14 0 15 0;
-#X connect 15 0 26 2;
-#X connect 17 0 15 1;
-#X connect 18 0 19 0;
-#X connect 19 0 20 0;
-#X connect 20 0 26 1;
-#X connect 21 0 20 1;
-#X connect 22 0 23 0;
-#X connect 23 0 24 0;
-#X connect 24 0 26 0;
-#X connect 25 0 24 1;
-#X connect 26 0 27 0;
-#X connect 29 0 7 0;
-#X connect 29 0 28 0;
-#X connect 30 0 29 0;
-#X connect 31 0 29 0;
-#X connect 35 0 30 2;
-#X connect 36 0 30 1;
-#X connect 37 0 30 0;
-#X connect 38 0 39 0;
-#X connect 39 0 30 0;
+#X connect 1 0 12 0;
+#X connect 1 0 16 0;
+#X connect 1 0 18 0;
+#X connect 4 0 2 0;
+#X connect 5 0 15 0;
+#X connect 6 0 14 0;
+#X connect 7 0 13 0;
+#X connect 9 0 2 0;
+#X connect 9 0 8 0;
+#X connect 10 0 9 0;
+#X connect 11 0 9 0;
+#X connect 13 0 10 2;
+#X connect 14 0 10 1;
+#X connect 15 0 10 0;
+#X connect 16 0 17 0;
+#X connect 17 0 10 0;
+#X restore -248 248 pd \$0-sliderguts;
+#X obj -248 107 vsl 15 128 0 127 0 0 \$0-lslider empty empty 0 -9 0
+10 -262144 -1 -1 9800 0;
+#X obj -224 107 vsl 15 128 0 127 0 0 \$0-mslider empty empty 0 -9 0
+10 -262144 -1 -1 7800 1;
+#X obj -199 107 vsl 15 128 0 127 0 0 \$0-rslider empty empty 0 -9 0
+10 -262144 -1 -1 4100 1;
+#X text 140 24 Click here to send random input values;
+#N canvas 335 303 450 300 randomguts 0;
+#X obj 84 144 noise~;
+#X obj 84 163 unsig~;
+#X obj 84 183 expr (1 + $f1) * 63.5 * $f2;
+#X obj 243 163 r \$0-random-toggle;
+#X obj 55 85 noise~;
+#X obj 55 104 unsig~;
+#X obj 55 124 expr (1 + $f1) * 63.5 * $f2;
+#X obj 214 105 r \$0-random-toggle;
+#X obj 27 7 noise~;
+#X obj 27 26 unsig~;
+#X obj 27 66 expr (1 + $f1) * 63.5 * $f2;
+#X obj 186 47 r \$0-random-toggle;
+#X obj 27 203 pack f f f;
+#X obj 27 224 s \$0-random-values;
+#X connect 0 0 1 0;
+#X connect 1 0 2 0;
+#X connect 2 0 12 2;
+#X connect 3 0 2 1;
+#X connect 4 0 5 0;
+#X connect 5 0 6 0;
+#X connect 6 0 12 1;
+#X connect 7 0 6 1;
+#X connect 8 0 9 0;
+#X connect 9 0 10 0;
+#X connect 10 0 12 0;
+#X connect 11 0 10 1;
+#X connect 12 0 13 0;
+#X restore 30 191 pd randomguts;

--- a/inputs/PD/SimpleSlider_3inputs.pd
+++ b/inputs/PD/SimpleSlider_3inputs.pd
@@ -1,29 +1,69 @@
-#N canvas 0 23 476 360 10;
-#X msg -185 112 connect localhost 6448;
-#X obj -102 260 packOSC;
-#X obj -102 293 udpsend;
-#X obj -185 83 loadbang;
-#X obj 7 28 vsl 15 128 0 127 0 0 empty empty empty 0 -9 0 10 -262144
--1 -1 4700 1;
-#X obj 32 27 vsl 15 128 0 127 0 0 empty empty empty 0 -9 0 10 -262144
--1 -1 11200 1;
-#X obj -24 184 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144
--1 -1;
-#X obj 56 28 vsl 15 128 0 127 0 0 empty empty empty 0 -9 0 10 -262144
--1 -1 2200 1;
-#X obj 26 200 pack f f f;
-#X msg -100 228 sendtyped /wek/inputs fff \$1 \$2 \$3;
+#N canvas 498 163 745 419 10;
+#X declare -lib oscx;
+#X msg -210 94 connect localhost 6448;
+#X obj -210 74 loadbang;
+#X obj 10 66 vsl 15 128 0 127 0 0 \$0-lslider empty empty 0 -9 0 10
+-262144 -1 -1 3450 1;
+#X obj 34 66 vsl 15 128 0 127 0 0 \$0-mslider empty empty 0 -9 0 10
+-262144 -1 -1 10750 1;
+#X obj 59 66 vsl 15 128 0 127 0 0 \$0-rslider empty empty 0 -9 0 10
+-262144 -1 -1 0 1;
 #X text -229 -8 This patch sends 3 inputs to wekinator on port 6448
 \, using message /wek/inputs;
-#X text 83 51 Use these sliders to change input values.;
-#X connect 0 0 2 0;
-#X connect 1 0 2 0;
-#X connect 3 0 0 0;
-#X connect 4 0 8 0;
-#X connect 5 0 6 0;
-#X connect 5 0 8 1;
-#X connect 6 0 8 0;
-#X connect 7 0 8 2;
-#X connect 7 0 6 0;
-#X connect 8 0 9 0;
-#X connect 9 0 1 0;
+#X text -85 36 Use these sliders to change input values.;
+#X obj -221 250 sendOSC;
+#X obj -223 23 import oscx;
+#X msg -222 53 disconnect;
+#X obj -184 134 r \$0-lslider;
+#X obj -156 155 r \$0-mslider;
+#X obj -127 175 r \$0-rslider;
+#X obj 154 303 noise~;
+#X obj 154 322 unsig~;
+#X obj 154 342 expr (1 + $f1) * 63.5 * $f2;
+#X obj 88 105 tgl 15 0 \$0-random-toggle empty empty 17 7 0 10 -262144
+-1 -1 0 1;
+#X obj 313 322 r \$0-random-toggle;
+#X obj 125 244 noise~;
+#X obj 125 263 unsig~;
+#X obj 125 283 expr (1 + $f1) * 63.5 * $f2;
+#X obj 284 264 r \$0-random-toggle;
+#X obj 97 166 noise~;
+#X obj 97 185 unsig~;
+#X obj 97 225 expr (1 + $f1) * 63.5 * $f2;
+#X obj 256 206 r \$0-random-toggle;
+#X obj 97 362 pack f f f;
+#X obj 97 383 s \$0-random-values;
+#X obj -170 250 print;
+#X msg -198 223 send /wek/inputs \$1 \$2 \$3;
+#X obj -184 198 pack f f f;
+#X obj -176 178 t b;
+#X obj -197 115 r \$0-random-values;
+#X text 85 70 Click this checkbox tosend random input values;
+#X text 88 127 ... or both if you feel sassy. :-)Either way \, watch
+the Pd console.;
+#X connect 0 0 7 0;
+#X connect 1 0 0 0;
+#X connect 9 0 7 0;
+#X connect 10 0 30 0;
+#X connect 11 0 30 1;
+#X connect 11 0 31 0;
+#X connect 12 0 30 2;
+#X connect 12 0 31 0;
+#X connect 13 0 14 0;
+#X connect 14 0 15 0;
+#X connect 15 0 26 2;
+#X connect 17 0 15 1;
+#X connect 18 0 19 0;
+#X connect 19 0 20 0;
+#X connect 20 0 26 1;
+#X connect 21 0 20 1;
+#X connect 22 0 23 0;
+#X connect 23 0 24 0;
+#X connect 24 0 26 0;
+#X connect 25 0 24 1;
+#X connect 26 0 27 0;
+#X connect 29 0 7 0;
+#X connect 29 0 28 0;
+#X connect 30 0 29 0;
+#X connect 31 0 30 0;
+#X connect 32 0 29 0;

--- a/inputs/PD/SimpleSlider_3inputs.pd
+++ b/inputs/PD/SimpleSlider_3inputs.pd
@@ -1,35 +1,34 @@
-#N canvas 492 166 745 419 10;
+#N canvas 492 166 568 419 10;
 #X declare -lib oscx;
 #X text -256 -12 This patch sends 3 inputs to wekinator on port 6448
 \, using message /wek/inputs;
-#X text -253 83 Use these sliders to change input values.;
-#X obj 124 29 tgl 15 0 \$0-random-toggle empty empty 17 7 0 10 -262144
+#X obj -71 62 tgl 15 0 \$0-random-toggle empty empty 17 7 0 10 -262144
 -1 -1 0 1;
 #X obj -251 65 tgl 15 0 \$0-sliders-on-off \$0-loadbang empty 17 7
 0 10 -262144 -1 -1 0 1;
 #X text -256 33 click here to turn the sliders on/off;
-#X text 153 123 Either way \, watch the Pd console.;
-#N canvas 331 364 450 300 \$0-sliderguts 0;
-#X msg -210 114 connect localhost 6448;
-#X obj -210 94 loadbang;
-#X obj -221 350 sendOSC;
-#X obj -223 53 import oscx;
-#X msg -222 73 disconnect;
-#X obj -174 189 r \$0-lslider;
-#X obj -156 227 r \$0-mslider;
-#X obj -127 265 r \$0-rslider;
-#X obj -170 350 print;
-#X msg -198 323 send /wek/inputs \$1 \$2 \$3;
-#X obj -184 304 pack f f f;
-#X obj -198 134 r \$0-random-values;
-#X msg -63 109 \; pd dsp 1;
-#X obj -127 285 + 0.0001;
-#X obj -156 246 + 0.0001;
-#X obj -174 208 + 0.0001;
-#X obj -188 153 tgl 15 0 empty \$0-sliders-on-off empty 17 7 0 10 -262144
+#X text -74 116 Either way \, watch the Pd console.;
+#N canvas 329 365 450 300 \$0-sliderguts 0;
+#X msg -210 -26 connect localhost 6448;
+#X obj -210 -46 loadbang;
+#X obj -221 210 sendOSC;
+#X obj -223 -87 import oscx;
+#X msg -222 -67 disconnect;
+#X obj -174 49 r \$0-lslider;
+#X obj -156 87 r \$0-mslider;
+#X obj -127 125 r \$0-rslider;
+#X obj -170 210 print;
+#X msg -198 183 send /wek/inputs \$1 \$2 \$3;
+#X obj -184 164 pack f f f;
+#X obj -198 -6 r \$0-random-values;
+#X msg -63 -31 \; pd dsp 1;
+#X obj -127 145 + 0.0001;
+#X obj -156 106 + 0.0001;
+#X obj -174 68 + 0.0001;
+#X obj -188 13 tgl 15 0 empty \$0-sliders-on-off empty 17 7 0 10 -262144
 -1 -1 0 1;
-#X obj -188 170 metro 12;
-#X obj -147 94 s \$0-loadbang;
+#X obj -188 30 metro 12;
+#X obj -147 -46 s \$0-loadbang;
 #X connect 0 0 2 0;
 #X connect 1 0 0 0;
 #X connect 1 0 12 0;
@@ -48,14 +47,13 @@
 #X connect 15 0 10 0;
 #X connect 16 0 17 0;
 #X connect 17 0 10 0;
-#X restore -248 248 pd \$0-sliderguts;
-#X obj -248 107 vsl 15 128 0 127 0 0 \$0-lslider empty empty 0 -9 0
+#X restore -79 229 pd \$0-sliderguts;
+#X obj -248 117 vsl 45 128 0 127 0 0 \$0-lslider empty empty 0 -9 0
 10 -262144 -1 -1 9800 0;
-#X obj -224 107 vsl 15 128 0 127 0 0 \$0-mslider empty empty 0 -9 0
-10 -262144 -1 -1 7800 1;
-#X obj -199 107 vsl 15 128 0 127 0 0 \$0-rslider empty empty 0 -9 0
-10 -262144 -1 -1 4100 1;
-#X text 140 24 Click here to send random input values;
+#X obj -194 117 vsl 45 128 0 127 0 0 \$0-mslider empty empty 0 -9 0
+10 -99865 -1 -1 7800 1;
+#X obj -139 117 vsl 45 128 0 127 0 0 \$0-rslider empty empty 0 -9 0
+10 -191407 -1 -1 4100 1;
 #N canvas 335 303 450 300 randomguts 0;
 #X obj 84 144 noise~;
 #X obj 84 163 unsig~;
@@ -84,4 +82,6 @@
 #X connect 10 0 12 0;
 #X connect 11 0 10 1;
 #X connect 12 0 13 0;
-#X restore 30 191 pd randomguts;
+#X restore 26 230 pd randomguts;
+#X text -253 83 Use these sliders to change input values.;
+#X text -75 30 Click here to send random input values;


### PR DESCRIPTION
I *think* the sliders are now what the author of the original patch was aiming for.

3 steady stream sliders & 3 random values, toggle buttons to turn each one on and off. You _can_ turn them both on at the same time, but I don't know why you'd want to. 

The sliders (and processing) are on when you open the patch. I put the guts in subpatches because it was getting messy. Has 'print' built-in so users can watch values in the Pd console.
The [+ 0.0001] in [pd sliderguts] is because that's the least-obtrusive way I've found to convert integers to floats in Pd. The [metro 12] is an arbitrary "really small value" between output signals. No, I don't know why the sliders periodically send 3 zeroes.

The random part sends a signal sort of like the Python example, except every 300 ms.